### PR TITLE
Clear player stream iterators upon disconnect.

### DIFF
--- a/foreach.inc
+++ b/foreach.inc
@@ -916,6 +916,18 @@ public OnGameModeInit()
 		#if FOREACH_I_Character
 			Iter_Remove(Character, playerid);
 		#endif
+
+		#if FOREACH_I_PlayerPlayersStream
+			Iter_Clear(PlayerPlayersStream[playerid]);
+		#endif
+
+		#if FOREACH_I_PlayerVehiclesStream
+			Iter_Clear(PlayerVehiclesStream[playerid]);
+		#endif
+
+		#if FOREACH_I_PlayerActorsStream
+			Iter_Clear(PlayerActorsStream[playerid]);
+		#endif
 	}
 
 #endif


### PR DESCRIPTION
I made a feature on my server where chat radius is adjusted in interior depending on how many players are streamed in. I noticed the radius seemed to be incorrect when it was only me and another player in an interior and I couldn't see his chat from a few meters away. I deduced that it's probably because the iterators aren't cleared when a player disconnects, and OnPlayerStreamOut isn't called in such a way that clears the iterator of the player who just disconnected.